### PR TITLE
Adding package ovmf for OVH servers on Debian 10

### DIFF
--- a/depenguinme.sh
+++ b/depenguinme.sh
@@ -3,7 +3,7 @@
 # depenguinme.sh
 
 # please bump version on change
-VERSION="v0.0.11"
+VERSION="v0.0.12"
 
 # v0.0.1  2022-07-28  bretton depenguin.me
 #  this is a proof of concept with parts to be further developed
@@ -54,6 +54,10 @@ VERSION="v0.0.11"
 #
 # v0.0.11 2023-05-27 bretton depenguin.me
 #  FreeBSD 13.2 release
+#
+# v0.0.12 2023-09-08 bretton depenguin.me
+#  Include package ovmf in DEPS
+#
 
 # this script must be run as root
 if [ "$EUID" -ne 0 ]; then
@@ -86,6 +90,7 @@ DEPS=(
   "mkisofs:mkisofs"
   "qemu-system-x86_64:qemu-system-x86"
   "kvm-ok:cpu-checker"
+  "ovmf:ovmf"
   )  # binary:package
 
 usage() {


### PR DESCRIPTION
There is no binary `ovmf` so `command -v ovmf` will always fail and cause an install. 
