### PR TITLE
add 2 more servers

### DIFF
--- a/SUPPORTED-SERVERS.md
+++ b/SUPPORTED-SERVERS.md
@@ -15,8 +15,10 @@ This is a list of confirmed working, or not working, dedicated server systems.
 * Hetzner AX51-NVMe (v.0.0.10, 2022-08-24, ipv6-only) [Issue-10](https://github.com/depenguin-me/depenguin-run/issues/10)
 * Hetzner EX43-NVMe (v.0.0.10, 2022-10-16, disable serial ports) [Issue-57](https://github.com/depenguin-me/depenguin-run/issues/57)
 * Hetzner AX41-NVMe (v 0.0.10, 2023-04-06, change interface in /etc/rc.conf) [Issue-10](https://github.com/depenguin-me/depenguin-run/issues/10#issuecomment-1225893163)
+* Hetzner AX101-NVMe (v0.0.15, 2024-02-13, change NIC in rc.conf from em0 to igb0)
 * Hetzner SB Intel Xeon E3-1275V6 (v 0.0.14, 2023-12-21, four disks used for mirror array)
 * Hetzner SB Intel Xeon E5-1650V3 (v 0.0.14, 2024-01-02, two HDD, two SSD)
+* online.net Start-3-L (v0.0.15, 2024-02-13, change NIC in rc.conf from em0 to igb0)
 * Xneelo Truserv Intel Xeon E3-1230V6 (v 0.0.14, 2024-01-04, four disks, local ipv6) [Issue-12](https://github.com/depenguin-me/depenguin-run/issues/12#issuecomment-1877658404)
 
 ## NOT WORKING


### PR DESCRIPTION
Hetzner AX101 and online.net Start-3-L worked fine, both had igb0 interfaces which needed tweaking after the installation.
Maybe `ifconfig_DEFAULT=...` could help here, I don't know how well that plays with bsdinstall and I don't know how it behaves with multiple NICs